### PR TITLE
fix the problem about multiprocessing and global variable

### DIFF
--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -90,9 +90,7 @@ def _account_marking(_account: str) -> List[bool]:
 
 
 def account_marking(_tweets: List[str], accounts: List[str]) -> List[List[bool]]:
-    global tweets
-    tweets = _tweets
-    pool = Pool()
+    pool = Pool(initializer=init_pool, initargs=(_tweets,))
     datamatrix = pool.map(_account_marking, accounts)
     pool.close()
     pool.join()
@@ -106,10 +104,12 @@ def _term_marking(_term: str) -> List[int]:
     return counts
 
 
-def term_marking(_tweets: List[str], terms: List[str]) -> List[List[int]]:
+def init_pool(_tweets: List[str]):
     global tweets
     tweets = _tweets
-    pool = Pool()
+
+def term_marking(_tweets: List[str], terms: List[str]) -> List[List[int]]:
+    pool = Pool(initializer=init_pool, initargs=(_tweets,))
     datamatrix = pool.map(_term_marking, terms)
     pool.close()
     pool.join()


### PR DESCRIPTION
Here are the details of the error infomation:
```
Traceback (most recent call last):
  File "TwiTi/classifier/classifier_builder.py", line 272, in <module>
    builder_main(save=True)
  File "TwiTi/classifier/classifier_builder.py", line 256, in builder_main
    dataframe_x = feature_scaler.fit_transform(df, df['y'])
  File "Python\Python3.7.0\lib\site-packages\sklearn\base.py", line 702, in fit_transform
    return self.fit(X, y, **fit_params).transform(X)
  File "TwiTi/classifier/classifier_builder.py", line 184, in fit
    word_features = mutual_selection(df_words, y.array, _WORD_MI_THRESHOLD, category="word")
  File "TwiTi/classifier/classifier_builder.py", line 144, in mutual_selection
    mutual_info = [mutual_info_score(df_x[feature], y) for feature in features]
  File "TwiTi/classifier/classifier_builder.py", line 144, in <listcomp>
    mutual_info = [mutual_info_score(df_x[feature], y) for feature in features]
  File "Python\Python3.7.0\lib\site-packages\sklearn\utils\validation.py", line 63, in inner_f
    return f(*args, **kwargs)
  File "Python\Python3.7.0\lib\site-packages\sklearn\metrics\cluster\_supervised.py", line 769, in mutual_info_score
    labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
  File "Python\Python3.7.0\lib\site-packages\sklearn\metrics\cluster\_supervised.py", line 67, in check_clusterings
    check_consistent_length(labels_true, labels_pred)
  File "Python\Python3.7.0\lib\site-packages\sklearn\utils\validation.py", line 263, in check_consistent_length
    " samples: %r" % [int(l) for l in lengths])
ValueError: Found input variables with inconsistent numbers of samples: [0, 20000]

Process finished with exit code 1
```